### PR TITLE
Fix Removing Powerplans on Non English Installs

### DIFF
--- a/6 Windows/9 Power Plan.ps1
+++ b/6 Windows/9 Power Plan.ps1
@@ -21,10 +21,20 @@ cmd /c "powercfg /duplicatescheme e9a42b02-d5df-448d-aa00-03f14749eb61 99999999-
 # set ultimate power plan active
 cmd /c "powercfg /SETACTIVE 99999999-9999-9999-9999-999999999999 >nul 2>&1"
 # get all powerplans
-$powerPlans = powercfg /list | Select-String -Pattern "GUID: ([\w-]+)" | ForEach-Object { $_.Matches.Groups[1].Value }
+$output = powercfg /L
+$powerPlans = @()
+foreach ($line in $output) {
+    #extract guid manually to avoid lang issues
+    if ($line -match ':') {
+        $parse = $line -split ':'
+        $index = $parse[1].Trim().indexof('(')
+        $guid = $parse[1].Trim().Substring(0, $index)
+        $powerPlans += $guid
+    }
+}
 # delete all powerplans
 foreach ($plan in $powerPlans) {
-powercfg -delete $plan
+    cmd /c "powercfg /delete $plan" | Out-Null
 }
 Clear-Host
 # disable hibernate


### PR DESCRIPTION
Issue: using the regular expression "GUID: ([\w-]+)" causes issues because some languages output GUID then "Power Scheme"
Example: 
![image](https://github.com/user-attachments/assets/97950641-1e0f-44aa-86f2-404f396fd056)

Fix: Extract GUID manually with string manipulation 